### PR TITLE
Update load-balancer-healthcheck.md

### DIFF
--- a/doc_source/load-balancer-healthcheck.md
+++ b/doc_source/load-balancer-healthcheck.md
@@ -4,14 +4,12 @@ The following diagram describes the load balancer health check process\. The loa
 
 ![\[Diagram showing the load balancer health checks.\]](http://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/images/load-balancer-healthcheck.PNG)
 
-There are two options in the health check that affect the deployment speed\. One is for the Amazon ECS task definition\. The other is for the load balancer\.
-+ `HealthCheckInterval`: 30 seconds \(default\)
-
-  For more information about the task definition health check interval parameter, see [Health Check](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_healthcheck) in the *Amazon Elastic Container Service Developer Guide*\.
+There are two options in the health check that affect the deployment speed\. These are for the load balancer\.
++ `HealthCheckIntervalSeconds`: 30 seconds \(default\)
 + `HealthyThresholdCount`: 5 \(default\)
 
 By default, the load balancer requires five passing health checks before it reports that the target container is healthy\. Each check is made 30 seconds apart\. In total, each time takes two minutes and 30 seconds \(`5*30/60`\)\. 
 
 If your service starts up and stabilizes in under 10 seconds, set the options to the following values to have the load balancer wait a total of 10 seconds:
-+ `HealthCheckInterval`: 5 
++ `HealthCheckIntervalSeconds`: 5 
 + `HealthyThresholdCount`: 2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the documentation issue.
AFAIK, the `HealthCheckInterval` option (for Task Definition) does not affect the load balancer's health check interval. It seems that the correct option is `HealthCheckIntervalSeconds` (for Target Group) in this context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
